### PR TITLE
Add support for passing custom arguments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,16 +4,17 @@ use console::style;
 /// # Errors
 /// Errors when cargo metadata fails
 pub fn run() -> Result<(), Error> {
-
-
-
     // Since this makes only sense on mac, return en error if running on a different platform
     if !cfg!(target_os = "macos") {
-        return Err(Error::UnsupportedOS)
+        return Err(Error::UnsupportedOS);
     }
 
     let args = std::env::args().skip(1).collect::<Vec<_>>();
-    let build_mode = if args.contains(&"release".to_string()) {"release"} else {"debug"};
+    let build_mode = if args.contains(&"--release".to_string()) {
+        "release"
+    } else {
+        "debug"
+    };
 
     let meta = cargo_metadata::MetadataCommand::new().exec()?;
     let exe_meta = meta.root_package().ok_or(Error::ExpectedPackage)?;
@@ -49,11 +50,13 @@ pub fn run() -> Result<(), Error> {
     std::process::Command::new("lipo")
         .arg("-create")
         .arg("-output")
-        .arg(output)
+        .arg(&output)
         .arg(x86_bin)
         .arg(arm_bin)
         .spawn()?
         .wait()?;
+    println!("{} {}", style("Output").green().bold(), &output.display());
+
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,12 +4,23 @@ use console::style;
 /// # Errors
 /// Errors when cargo metadata fails
 pub fn run() -> Result<(), Error> {
+
+
+
+    // Since this makes only sense on mac, return en error if running on a different platform
+    if !cfg!(target_os = "macos") {
+        return Err(Error::UnsupportedOS)
+    }
+
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    let build_mode = if args.contains(&"release".to_string()) {"release"} else {"debug"};
+
     let meta = cargo_metadata::MetadataCommand::new().exec()?;
     let exe_meta = meta.root_package().ok_or(Error::ExpectedPackage)?;
     println!("{} x86_64", style("Building").green().bold());
     std::process::Command::new("cargo")
         .arg("build")
-        .arg("--release")
+        .args(&args)
         .arg("--target")
         .arg("x86_64-apple-darwin")
         .spawn()?
@@ -17,23 +28,23 @@ pub fn run() -> Result<(), Error> {
     println!("{} aarch64", style("Building").green().bold());
     std::process::Command::new("cargo")
         .arg("build")
-        .arg("--release")
+        .args(&args)
         .arg("--target")
         .arg("aarch64-apple-darwin")
         .spawn()?
         .wait()?;
     println!("{} {}", style("Linking").green().bold(), &exe_meta.name);
     let root_path = meta.target_directory.canonicalize()?;
-    let mut output = root_path.join("universal2-apple-darwin").join("release");
+    let mut output = root_path.join("universal2-apple-darwin").join(build_mode);
     std::fs::create_dir_all(&output)?;
     output.push(&exe_meta.name);
     let x86_bin = root_path
         .join("x86_64-apple-darwin")
-        .join("release")
+        .join(build_mode)
         .join(&exe_meta.name);
     let arm_bin = root_path
         .join("aarch64-apple-darwin")
-        .join("release")
+        .join(build_mode)
         .join(&exe_meta.name);
     std::process::Command::new("lipo")
         .arg("-create")
@@ -54,4 +65,6 @@ pub enum Error {
     CargoMetadata(#[from] cargo_metadata::Error),
     #[error("Expected at least one package!")]
     ExpectedPackage,
+    #[error("This operating system is unsupported!")]
+    UnsupportedOS,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,10 @@ pub fn run() -> Result<(), Error> {
         return Err(Error::UnsupportedOS);
     }
 
-    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    let mut args = std::env::args().skip(1).collect::<Vec<_>>();
+    if args.is_empty() {
+        args.push("--release".to_owned());
+    }
     let build_mode = if args.contains(&"--release".to_string()) {
         "release"
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ use console::style;
 /// # Errors
 /// Errors when cargo metadata fails
 pub fn run() -> Result<(), Error> {
-    // Since this makes only sense on mac, return en error if running on a different platform
+    // Since this makes only sense on mac, return an error if running on a different platform
     if !cfg!(target_os = "macos") {
         return Err(Error::UnsupportedOS);
     }


### PR DESCRIPTION
This PR adds support for custom variables to cargo-universal2. This would allow building with different features or in debug/release mode.

This also adds a check to run on macos only.